### PR TITLE
Fix no active tabs onload

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -237,7 +237,7 @@ function setActiveTab(elm, _isMatchingTabSync = false) {
  */
 function setActiveTabFromAnchor() {
     const match                 = window.location.hash.match(/(?:id=)([^&]+)/);
-    const anchorID              = anchorID = (match ? match[1] : "");
+    const anchorID              = match ? match[1] : "";
     const anchorSelector        = `.${classNames.tabBlock} #${anchorID.indexOf('%') > -1 ? decodeURIComponent(anchorID) : anchorID}`;
     const isAnchorElmInTabBlock = anchorID && document.querySelector(anchorSelector);
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -236,7 +236,8 @@ function setActiveTab(elm, _isMatchingTabSync = false) {
  * Sets the active tab based on the anchor ID in the URL
  */
 function setActiveTabFromAnchor() {
-    const anchorID              = (window.location.hash.match(/(?:id=)([^&]+)/) || [])[1];
+    const match                 = window.location.hash.match(/(?:id=)([^&]+)/);
+    const anchorID              = anchorID = (match ? match[1] : "");
     const anchorSelector        = `.${classNames.tabBlock} #${anchorID.indexOf('%') > -1 ? decodeURIComponent(anchorID) : anchorID}`;
     const isAnchorElmInTabBlock = anchorID && document.querySelector(anchorSelector);
 


### PR DESCRIPTION
Fixes the breaking changes introduced in version 1.4.1

With version 1.4.1 if the URL does not contain any id, for example `?id=something`, there is a javascript error triggered due to the return value of the `anchorID` match being undefined. I've changed the markup to check if there is a match or not, if there is one, return the matched string, if there is none, return an empty string `""` since the 1st index of location match is always a string and not necessarily an array.

Fixes #23