### PR TITLE
Avoid (comment) tab content being ended on tabs:replace

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -36,7 +36,7 @@ const regex = {
     // 0: Match
     // 1: Label: <!-- tab:Label -->
     // 2: Content
-    tabCommentMarkup: /[\r\n]*(\s*)<!-+\s+tab:\s*(.*)\s+-+>[\r\n]+([\s\S]*?)[\r\n]*\s*(?=<!-+\s+tabs?:)/m,
+    tabCommentMarkup: /[\r\n]*(\s*)<!-+\s+tab:\s*(.*)\s+-+>[\r\n]+([\s\S]*?)[\r\n]*\s*(?=<!-+\s+(tab:\s*(.*)|tabs:\s*?end)\s+-+>)/m,
 
     // Matches tab label and content
     // 0: Match


### PR DESCRIPTION
Closes #29.

Currently the comment markup regex
https://github.com/jhildenbiddle/docsify-tabs/blob/bc0c1feafd8ad9cdd2276e21bc04f97a2ec37671/src/js/index.js#L39
is such that content of a single tab ends when it reaches something matching `<!-+\s+tabs?:`, which includes `<!-- tabs:replace CODEBLOCKi -->` temporarily inserted by `docsify-tabs` instead of code blocks.

Adding a code block (in tab comment mode) therefore effectively ends tab content too early.

One solution might be to match  `tab:TITLE` and `tabs:end` (and thereby not `tabs:replace`), by doing
```
<!-+\s+(tab:\s*(.*)|tabs:\s*?end)\s+-+>
```
instead of existing `<!-+\s+tabs?:`. The extra regex `or` (`|`) is then also conceptually used in the same way as currently in `tabHeadings` regex,
```
#{1,6}\s*[*_]{2}|<!-+\s+tabs:\s*?end\s+-+>
```
where we first match new tabs, and then end of the whole tab group.