### PR TITLE
Fix minor typos in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,7 +120,7 @@ This is some text.
 
 1. Define a tab set using `tabs:start` and `tabs:end` HTML comments.
 
-   HTML comments are used to mark the start and end of a tab set. The use of HTML comments prevents tab-related markup from being displayed when markdown is rendered as HTML outside of your docsify site (e.g. Github, GitLab, etc).
+   HTML comments are used to mark the start and end of a tab set. The use of HTML comments prevents tab-related markup from being displayed when markdown is rendered as HTML outside of your docsify site (e.g. GitHub, GitLab, etc).
 
    ```markdown
    <!-- tabs:start -->
@@ -355,7 +355,7 @@ Ciao!
 
 Determines if tabs within a tab set can be defined using heading + bold markdown.
 
-The use of heading + bold markdown allows tabs to be defined using standard markdown and ensures that tab content is displayed with a heading when rendered outside of your docsify site (e.g. GitHub, GitLab, etc). Heading levels 1-6 are supported (e.g. `#` - `######`) as are both asteriscks (`**`) and underscores (`__`) for bold text via markdown.
+The use of heading + bold markdown allows tabs to be defined using standard markdown and ensures that tab content is displayed with a heading when rendered outside of your docsify site (e.g. GitHub, GitLab, etc). Heading levels 1-6 are supported (e.g. `#` - `######`) as are both asterisks (`**`) and underscores (`__`) for bold text via markdown.
 
 **Configuration**
 

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -1,6 +1,6 @@
 - [Documentation](/)
 - [Changelog](changelog)
 - **Links**
-- [![Github](assets/img/github.svg)Github](https://github.com/jhildenbiddle/docsify-tabs)
+- [![GitHub](assets/img/github.svg)GitHub](https://github.com/jhildenbiddle/docsify-tabs)
 - [![NPM](assets/img/npm.svg)NPM](https://www.npmjs.com/package/docsify-tabs)
 - [![Twitter](assets/img/twitter.svg)@jhildenbiddle](http://twitter.com/jhildenbiddle)


### PR DESCRIPTION
Change

- “asteris**c**ks” to “asterisks”;
- “Git**h**ub to “Git**H**ub”.