### PR TITLE
fix bug: render error

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,7 @@ const regex = {
     // Matches tab replacement comment
     // 0: Match
     // 1: Replacement HTML
-    commentReplaceMarkup: new RegExp(`<!-- ${commentReplaceMark} (.*) -->`),
+    commentReplaceMarkup: new RegExp(`<!-- ${commentReplaceMark} (.*?) -->`),
 
     // Matches tab set by start/end comment
     // 0: Match


### PR DESCRIPTION
I find a page that was rendered as below.

![image](https://user-images.githubusercontent.com/71511961/188858374-29111e8d-04fc-42d5-9eb2-466dc15c558a.png)

But what I want is like this:

![image](https://user-images.githubusercontent.com/71511961/188858961-17aede74-be35-4a0e-8b0e-a5cecefa7894.png)

I find the reason why it can't render correctly is that the regex below is not suitable for some situations.

```js
commentReplaceMarkup: new RegExp(`<!-- ${commentReplaceMark} (.*) -->`)
```

- for example

  ```html
  <!-- tabs:replace </div> --></li><li><p>hi</p><!-- tabs:replace <div class="docsify-tabs docsify-tabs--classic"> -->
  ```

  This will match the content `</div> --></li><li><p>hi</p><!-- tabs:replace <div class="docsify-tabs docsify-tabs--classic">` instead of `</div>`

I think the right regex should be like this:

```js
commentReplaceMarkup: new RegExp(`<!-- ${commentReplaceMark} (.*?) -->`)
```

