### PR TITLE
New fix for #27

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -33,7 +33,7 @@
 }
 
 .docsify-tabs__content {
-    visibility: hidden;
+    display:none;
     position: absolute;
     overflow: hidden;
     height: 0;
@@ -49,7 +49,7 @@
     }
 
     .docsify-tabs__tab--active + & {
-        visibility: visible;
+        display:block;
         position: relative;
         overflow: auto;
         height: auto;


### PR DESCRIPTION
Hello,

Even with the last version of the plugin, I have the same issue as #27.
Digging into the CSS, my team and I found out that it was just caused by the use of "visibility" instead of "display".

On both my production environment and demonstrator, this fixes the issue.