### PR TITLE
fix: incorrect scrolling to anchor

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -56,6 +56,15 @@
   }
 }
 
+.docsify-tabs:not(:has(> button.docsify-tabs__tab--active)) > .docsify-tabs__content[class]:nth-child(2) {
+  visibility: visible;
+  position: relative;
+  overflow: auto;
+  height: auto;
+
+  padding: var(--docsifytabs-content-padding);
+}
+
 // Themes
 // =============================================================================
 [class*='docsify-tabs--'] {


### PR DESCRIPTION
Hello!
I want to return to [this](https://github.com/jhildenbiddle/docsify-tabs/issues/8) story with anchor positioning.
I'm aware of your (@jhildenbiddle) comments [here](https://github.com/jhildenbiddle/docsify-tabs/issues/8#issuecomment-580074636) and agree with them: this work should be done on docsify's side and in general (for plugins and images). It is currently 2024, so we are waiting for this feature in `docsify` any minute now.

But there is the one simple solution, you can make to drastically reduce impact of such annoying and imperfect bug.
Lets just take the first tab and make it's content height visible on CSS level. With turned off persistent mode it solves the issue! Just because it does it's job before `setDefaultTabs()` in `hook.doneEach`.

Perhaps this will give you some thoughts on how to handle the persistent mode. For me, this solution proved to be sufficient.

If someone want to use it before this PR is merged — here is the CSS code:
```css
.docsify-tabs:not(:has(> button.docsify-tabs__tab--active)) > .docsify-tabs__content[class]:nth-child(2) {
    visibility: visible;
    position: relative;
    overflow: auto;
    height: auto;

    padding: var(--docsifytabs-content-padding);
}
```